### PR TITLE
chore: rename to gh-gfm-preview

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 builds:
   - env:
       - CGO_ENABLED=0
-    ldflags: -s -w -X github.com/thiagokokada/gfm-markdown-preview/cmd.Version={{.Tag}}
+    ldflags: -s -w -X github.com/thiagokokada/gh-gfm-preview/cmd.Version={{.Tag}}
     goos:
       - linux
       - windows

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# GFM markdown-preview
+# GH gfm-preview
 
 A Go program to preview GitHub Flavored Markdown :octocat:.
 
-The `gfm-markdown-preview` command start a local web server to serve the
-markdown document. **gfm-markdown-preview** renders the HTML using
+The `gh-gfm-preview` command start a local web server to serve the markdown
+document. **gh gfm-preview** renders the HTML using
 [yuin/goldmark](https://github.com/yuin/goldmark) and some extensions to have
 similar features and look to how GitHub renders a markdown.
 
@@ -30,7 +30,7 @@ You need to have [Go](https://go.dev/) installed.
 ### Standalone
 
 ```
-go run github.com/thiagokokada/gfm-markdown-preview
+go run github.com/thiagokokada/gh-gfm-preview
 ```
 
 ### Nix
@@ -38,13 +38,13 @@ go run github.com/thiagokokada/gfm-markdown-preview
 Assuming that you have [Flakes](https://wiki.nixos.org/wiki/Flakes) enabled:
 
 ```
-nix run github:thiagokokada/gfm-markdown-preview
+nix run github:thiagokokada/gh-gfm-preview
 ```
 
 ### GitHub Extension
 
 ```
-gh extension install thiagokokada/gfm-markdown-preview
+gh extension install thiagokokada/gh-gfm-preview
 ```
 
 Upgrade:
@@ -58,13 +58,13 @@ gh extension upgrade markdown-preview
 The usage:
 
 ```
-gfm-markdown-preview README.md
+gh-gfm-preview README.md
 ```
 
 Or this command will detect README file in the directory automatically.
 
 ```
-gfm-markdown-preview
+gh-gfm-preview
 ```
 
 Then access the local web server such as `http://localhost:3333` with Chrome,
@@ -76,7 +76,7 @@ Available options:
     --dark-mode           force dark mode
     --disable-auto-open   disable auto opening your browser
     --disable-reload      disable live reloading
--h, --help                help for gfm-markdown-preview
+-h, --help                help for gh-gfm-preview
     --host string         hostname this server will bind (default "localhost")
     --light-mode          force light mode
     --markdown-mode       force "markdown" mode (rather than default "gfm")

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -21,7 +21,7 @@ type Param struct {
 	autoOpen       bool
 }
 
-var programName = "gfm-markdown-preview"
+var programName = "gh-gfm-preview"
 var rootCmd = &cobra.Command{
 	Use:   programName,
 	Short: "GitHub CLI extension to preview Markdown",

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "gfm-markdown-preview";
+  description = "gh-gfm-preview";
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
@@ -38,8 +38,8 @@
           pkgs = nixpkgsFor.${system};
         in
         {
-          default = self.packages.${system}.gfm-markdown-preview;
-          gfm-markdown-preview = pkgs.callPackage ./gfm-markdown-preview.nix { inherit version; };
+          default = self.packages.${system}.gh-gfm-preview;
+          gh-gfm-preview = pkgs.callPackage ./gh-gfm-preview.nix { inherit version; };
         }
       );
 

--- a/gh-gfm-preview
+++ b/gh-gfm-preview
@@ -5,7 +5,7 @@ tag="0.0.1"
 
 extension_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 tag_path="${extension_path}/dist/${tag}"
-exe="gfm-markdown-preview"
+exe="gh-gfm-preview"
 
 if [ ! -e "${tag_path}/${exe}" ]; then
   if [ "$(which go)" == "" ]; then

--- a/gh-gfm-preview.nix
+++ b/gh-gfm-preview.nix
@@ -5,7 +5,7 @@
 }:
 
 buildGoModule {
-  pname = "gfm-markdown-preview";
+  pname = "gh-gfm-preview";
   inherit version;
   src = lib.cleanSource ./.;
   vendorHash = "sha256-RYEaK9/CeKlPdfPogGBpRM4FgFS6ZCFJnC2UOn7x7fg=";
@@ -21,8 +21,8 @@ buildGoModule {
 
   meta = with lib; {
     description = "A Go program to preview GitHub Flavored Markdown";
-    homepage = "https://github.com/thiagokokada/gfm-markdown-preview";
+    homepage = "https://github.com/thiagokokada/gh-gfm-preview";
     license = licenses.mit;
-    mainProgram = "gfm-markdown-preview";
+    mainProgram = "gh-gfm-preview";
   };
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/thiagokokada/gfm-markdown-preview
+module github.com/thiagokokada/gh-gfm-preview
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	cmd "github.com/thiagokokada/gfm-markdown-preview/cmd"
+	cmd "github.com/thiagokokada/gh-gfm-preview/cmd"
 )
 
 func main() {


### PR DESCRIPTION
GH extensions needs to start with `gh`.