### PR TITLE
feat: simplify dark-mode logic

### DIFF
--- a/gh-gfm-preview.nix
+++ b/gh-gfm-preview.nix
@@ -8,7 +8,7 @@ buildGoModule {
   pname = "gh-gfm-preview";
   inherit version;
   src = lib.cleanSource ./.;
-  vendorHash = "sha256-fkFn1Z8DlCa0asdXIbfZJnrWYBhOOyS/so7ZGDSNtUk=";
+  vendorHash = "sha256-i7oPa//HYTHuQBXAWCNJoH3RN0katJ9cbZrADUYCuBE=";
 
   env.CGO_ENABLED = "0";
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.9.1
-	github.com/thiagokokada/dark-mode-go v0.0.1
 	github.com/thiagokokada/goldmark-gh-alerts v0.0.0-20250302164040-cf407c0ddfaf
 	github.com/yuin/goldmark v1.7.8
 	github.com/yuin/goldmark-emoji v1.0.5
@@ -19,7 +18,6 @@ require (
 
 require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -35,8 +33,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/thiagokokada/dark-mode-go v0.0.1 h1:layfdBOM9xaxBa1Dw6f97ng/GbRJh+f8+afBOvDzXz4=
-github.com/thiagokokada/dark-mode-go v0.0.1/go.mod h1:IQrRBLMIz8vfFZ/sdZr7ASfW1SpE9TJwUCDbKbG2AQU=
 github.com/thiagokokada/goldmark-gh-alerts v0.0.0-20250302164040-cf407c0ddfaf h1:9Iw9iwgonqXIcxOWWNFt4RM64N+ZdNaVajqehannr+o=
 github.com/thiagokokada/goldmark-gh-alerts v0.0.0-20250302164040-cf407c0ddfaf/go.mod h1:09li+48KzZ5zboCXexzU9grKMSvlvm8wn50pCiAP6Ec=
 github.com/yuin/goldmark v1.4.15/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,8 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/alecthomas/chroma/v2"
-	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/alecthomas/chroma/v2/formatters/html"
 	"github.com/thiagokokada/gh-gfm-preview/internal/utils"
 	alerts "github.com/thiagokokada/goldmark-gh-alerts"
 	"github.com/yuin/goldmark"
@@ -30,22 +29,6 @@ var alertIconMap = map[string]string{
 	"warning":   `<svg class="octicon octicon-alert mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>`,
 	"caution":   `<svg class="octicon octicon-stop mr-2" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path d="M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path></svg>`,
 }
-
-var githubStyle = utils.Must(
-	styles.Get("github").Builder().AddEntry(
-		chroma.Background, chroma.StyleEntry{
-			Background: chroma.NewColour(246, 248, 250),
-		},
-	).Build(),
-)
-
-var githubStyleDark = utils.Must(
-	styles.Get("github-dark").Builder().AddEntry(
-		chroma.Background, chroma.StyleEntry{
-			Background: chroma.NewColour(21, 27, 35),
-		},
-	).Build(),
-)
 
 var errFileNotFound = errors.New("file not found")
 
@@ -73,12 +56,7 @@ func TargetFile(filename string) (string, error) {
 	return filename, err
 }
 
-func ToHTML(markdown string, isMarkdownMode bool, isDarkMode bool) (string, error) {
-	style := githubStyle
-	if isDarkMode {
-		style = githubStyleDark
-	}
-
+func ToHTML(markdown string, isMarkdownMode bool) (string, error) {
 	extensions := goldmark.WithExtensions()
 	if !isMarkdownMode {
 		extensions = goldmark.WithExtensions(
@@ -86,7 +64,9 @@ func ToHTML(markdown string, isMarkdownMode bool, isDarkMode bool) (string, erro
 			&alerts.GhAlerts{Icons: alertIconMap},
 			extension.GFM,
 			emoji.Emoji,
-			highlighting.NewHighlighting(highlighting.WithCustomStyle(style)),
+			highlighting.NewHighlighting(
+				highlighting.WithFormatOptions(html.WithClasses(true)),
+			),
 		)
 	}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -76,7 +76,7 @@ func TestSlurp(t *testing.T) {
 func TestToHTML(t *testing.T) {
 	markdown := "text"
 
-	html, err := ToHTML(markdown, false, false)
+	html, err := ToHTML(markdown, false)
 	if err != nil {
 		t.Errorf("%s", err.Error())
 	}
@@ -95,7 +95,7 @@ func TestGfmCheckboxes(t *testing.T) {
 		t.Errorf("%s", err.Error())
 	}
 
-	html, err := ToHTML(result, false, true)
+	html, err := ToHTML(result, false)
 	if err != nil {
 		t.Errorf("%s", err.Error())
 	}
@@ -137,7 +137,7 @@ func TestGfmAlerts(t *testing.T) {
 		t.Errorf("%s", err.Error())
 	}
 
-	html, err := ToHTML(result, false, true)
+	html, err := ToHTML(result, false)
 	if err != nil {
 		t.Errorf("%s", err.Error())
 	}

--- a/internal/server/_tools/generate-assets.go
+++ b/internal/server/_tools/generate-assets.go
@@ -8,11 +8,31 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/styles"
 )
 
 const assetsDir = "./static"
 
 func main() {
+	githubStyle := fatal(
+		styles.Get("github").Builder().AddEntry(
+			chroma.Background,
+			chroma.StyleEntry{Background: chroma.NewColour(246, 248, 250)},
+		).Build(),
+	)
+	genChromaCss(githubStyle, assetsDir+"/chroma-github-light.css")
+
+	githubStyleDark := fatal(
+		styles.Get("github-dark").Builder().AddEntry(
+			chroma.Background,
+			chroma.StyleEntry{Background: chroma.NewColour(21, 27, 35)},
+		).Build(),
+	)
+	genChromaCss(githubStyleDark, assetsDir+"/chroma-github-dark.css")
+
 	getAsset(
 		"https://github.githubassets.com/favicons/favicon.svg",
 		assetsDir+"/favicon.svg",
@@ -156,11 +176,14 @@ func main() {
 	)
 }
 
-func fatal[T any](v T, err error) T {
+func fatal0(err error) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+}
 
+func fatal[T any](v T, err error) T {
+	fatal0(err)
 	return v
 }
 
@@ -186,6 +209,15 @@ Got: %s
 	out := fatal(os.Create(dest))
 	defer out.Close()
 	fatal(out.Write(bs))
+
+	fmt.Printf("Generated %s successfully\n", dest)
+}
+
+func genChromaCss(style *chroma.Style, dest string) {
+	formatter := html.New(html.WithClasses(true))
+	file := fatal(os.Create(dest))
+	defer file.Close()
+	fatal0(formatter.WriteCSS(file, style))
 
 	fmt.Printf("Generated %s successfully\n", dest)
 }

--- a/internal/server/mode.go
+++ b/internal/server/mode.go
@@ -1,20 +1,15 @@
 package server
 
-import (
-	"github.com/thiagokokada/dark-mode-go"
-	"github.com/thiagokokada/gh-gfm-preview/internal/utils"
-)
-
 type mode int
 
 const (
-	darkMode mode = iota
+	autoMode mode = iota
+	darkMode
 	lightMode
-	defaultMode = darkMode
 )
 
 func (m mode) String() string {
-	return [...]string{"dark", "light"}[m]
+	return [...]string{"auto", "dark", "light"}[m]
 }
 
 func (param *Param) getMode() mode {
@@ -23,21 +18,5 @@ func (param *Param) getMode() mode {
 	} else if param.ForceLightMode {
 		return lightMode
 	}
-
-	isDark, err := dark.IsDarkMode()
-	utils.LogDebug("Debug [auto-detected dark mode]: isDark=%v, err=%v", isDark, err)
-
-	if err != nil {
-		return defaultMode
-	}
-
-	if isDark {
-		return darkMode
-	}
-
-	return lightMode
-}
-
-func (param *Param) isDarkMode() bool {
-	return param.getMode() == darkMode
+	return autoMode
 }

--- a/internal/server/mode.go
+++ b/internal/server/mode.go
@@ -18,5 +18,6 @@ func (param *Param) getMode() mode {
 	} else if param.ForceLightMode {
 		return lightMode
 	}
+
 	return autoMode
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/thiagokokada/gh-gfm-preview/internal/utils"
 )
 
-//go:generate go run _tools/download-assets.go
+//go:generate go run _tools/generate-assets.go
 
 //go:embed template.html
 var htmlTemplate string
@@ -123,7 +123,7 @@ func mdResponse(w http.ResponseWriter, filename string, param *Param) string {
 		return ""
 	}
 
-	html, err := app.ToHTML(markdown, param.MarkdownMode, param.isDarkMode())
+	html, err := app.ToHTML(markdown, param.MarkdownMode)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 

--- a/internal/server/static/chroma-github-dark.css
+++ b/internal/server/static/chroma-github-dark.css
@@ -1,0 +1,83 @@
+/* Background */ .bg { background-color: #151b23; }
+/* PreWrapper */ .chroma { background-color: #151b23; }
+/* Error */ .chroma .err { color: #f85149 }
+/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { background-color: #6e7681 }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #737679 }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: #ff7b72 }
+/* KeywordConstant */ .chroma .kc { color: #79c0ff }
+/* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
+/* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
+/* KeywordPseudo */ .chroma .kp { color: #79c0ff }
+/* KeywordReserved */ .chroma .kr { color: #ff7b72 }
+/* KeywordType */ .chroma .kt { color: #ff7b72 }
+/* Name */ .chroma .n { color: #e6edf3 }
+/* NameAttribute */ .chroma .na { color: #e6edf3 }
+/* NameBuiltin */ .chroma .nb { color: #e6edf3 }
+/* NameBuiltinPseudo */ .chroma .bp { color: #e6edf3 }
+/* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
+/* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
+/* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
+/* NameEntity */ .chroma .ni { color: #ffa657 }
+/* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
+/* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
+/* NameFunctionMagic */ .chroma .fm { color: #e6edf3 }
+/* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
+/* NameNamespace */ .chroma .nn { color: #ff7b72 }
+/* NameOther */ .chroma .nx { color: #e6edf3 }
+/* NameProperty */ .chroma .py { color: #79c0ff }
+/* NameTag */ .chroma .nt { color: #7ee787 }
+/* NameVariable */ .chroma .nv { color: #79c0ff }
+/* NameVariableClass */ .chroma .vc { color: #e6edf3 }
+/* NameVariableGlobal */ .chroma .vg { color: #e6edf3 }
+/* NameVariableInstance */ .chroma .vi { color: #e6edf3 }
+/* NameVariableMagic */ .chroma .vm { color: #e6edf3 }
+/* Literal */ .chroma .l { color: #a5d6ff }
+/* LiteralDate */ .chroma .ld { color: #79c0ff }
+/* LiteralString */ .chroma .s { color: #a5d6ff }
+/* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
+/* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
+/* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
+/* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
+/* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
+/* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
+/* LiteralStringEscape */ .chroma .se { color: #79c0ff }
+/* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
+/* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
+/* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
+/* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
+/* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
+/* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
+/* LiteralNumber */ .chroma .m { color: #a5d6ff }
+/* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
+/* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
+/* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
+/* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
+/* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
+/* Operator */ .chroma .o { color: #ff7b72; font-weight: bold }
+/* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
+/* Comment */ .chroma .c { color: #8b949e; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
+/* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
+/* Generic */ .chroma .g { color: #e6edf3 }
+/* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
+/* GenericEmph */ .chroma .ge { color: #e6edf3; font-style: italic }
+/* GenericError */ .chroma .gr { color: #ffa198 }
+/* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
+/* GenericOutput */ .chroma .go { color: #8b949e }
+/* GenericPrompt */ .chroma .gp { color: #8b949e }
+/* GenericStrong */ .chroma .gs { color: #e6edf3; font-weight: bold }
+/* GenericSubheading */ .chroma .gu { color: #79c0ff }
+/* GenericTraceback */ .chroma .gt { color: #ff7b72 }
+/* GenericUnderline */ .chroma .gl { color: #e6edf3; text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #6e7681 }

--- a/internal/server/static/chroma-github-light.css
+++ b/internal/server/static/chroma-github-light.css
@@ -1,0 +1,70 @@
+/* Background */ .bg { background-color: #f6f8fa; }
+/* PreWrapper */ .chroma { background-color: #f6f8fa; }
+/* Error */ .chroma .err { color: #f6f8fa; background-color: #82071e }
+/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { background-color: #e5e5e5 }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: #cf222e }
+/* KeywordConstant */ .chroma .kc { color: #cf222e }
+/* KeywordDeclaration */ .chroma .kd { color: #cf222e }
+/* KeywordNamespace */ .chroma .kn { color: #cf222e }
+/* KeywordPseudo */ .chroma .kp { color: #cf222e }
+/* KeywordReserved */ .chroma .kr { color: #cf222e }
+/* KeywordType */ .chroma .kt { color: #cf222e }
+/* NameAttribute */ .chroma .na { color: #1f2328 }
+/* NameBuiltin */ .chroma .nb { color: #6639ba }
+/* NameBuiltinPseudo */ .chroma .bp { color: #6a737d }
+/* NameClass */ .chroma .nc { color: #1f2328 }
+/* NameConstant */ .chroma .no { color: #0550ae }
+/* NameDecorator */ .chroma .nd { color: #0550ae }
+/* NameEntity */ .chroma .ni { color: #6639ba }
+/* NameFunction */ .chroma .nf { color: #6639ba }
+/* NameLabel */ .chroma .nl { color: #990000; font-weight: bold }
+/* NameNamespace */ .chroma .nn { color: #24292e }
+/* NameOther */ .chroma .nx { color: #1f2328 }
+/* NameTag */ .chroma .nt { color: #0550ae }
+/* NameVariable */ .chroma .nv { color: #953800 }
+/* NameVariableClass */ .chroma .vc { color: #953800 }
+/* NameVariableGlobal */ .chroma .vg { color: #953800 }
+/* NameVariableInstance */ .chroma .vi { color: #953800 }
+/* LiteralString */ .chroma .s { color: #0a3069 }
+/* LiteralStringAffix */ .chroma .sa { color: #0a3069 }
+/* LiteralStringBacktick */ .chroma .sb { color: #0a3069 }
+/* LiteralStringChar */ .chroma .sc { color: #0a3069 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #0a3069 }
+/* LiteralStringDoc */ .chroma .sd { color: #0a3069 }
+/* LiteralStringDouble */ .chroma .s2 { color: #0a3069 }
+/* LiteralStringEscape */ .chroma .se { color: #0a3069 }
+/* LiteralStringHeredoc */ .chroma .sh { color: #0a3069 }
+/* LiteralStringInterpol */ .chroma .si { color: #0a3069 }
+/* LiteralStringOther */ .chroma .sx { color: #0a3069 }
+/* LiteralStringRegex */ .chroma .sr { color: #0a3069 }
+/* LiteralStringSingle */ .chroma .s1 { color: #0a3069 }
+/* LiteralStringSymbol */ .chroma .ss { color: #032f62 }
+/* LiteralNumber */ .chroma .m { color: #0550ae }
+/* LiteralNumberBin */ .chroma .mb { color: #0550ae }
+/* LiteralNumberFloat */ .chroma .mf { color: #0550ae }
+/* LiteralNumberHex */ .chroma .mh { color: #0550ae }
+/* LiteralNumberInteger */ .chroma .mi { color: #0550ae }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #0550ae }
+/* LiteralNumberOct */ .chroma .mo { color: #0550ae }
+/* Operator */ .chroma .o { color: #0550ae }
+/* OperatorWord */ .chroma .ow { color: #0550ae }
+/* Punctuation */ .chroma .p { color: #1f2328 }
+/* Comment */ .chroma .c { color: #57606a }
+/* CommentHashbang */ .chroma .ch { color: #57606a }
+/* CommentMultiline */ .chroma .cm { color: #57606a }
+/* CommentSingle */ .chroma .c1 { color: #57606a }
+/* CommentSpecial */ .chroma .cs { color: #57606a }
+/* CommentPreproc */ .chroma .cp { color: #57606a }
+/* CommentPreprocFile */ .chroma .cpf { color: #57606a }
+/* GenericDeleted */ .chroma .gd { color: #82071e; background-color: #ffebe9 }
+/* GenericEmph */ .chroma .ge { color: #1f2328 }
+/* GenericInserted */ .chroma .gi { color: #116329; background-color: #dafbe1 }
+/* GenericOutput */ .chroma .go { color: #1f2328 }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #ffffff }

--- a/internal/server/template.html
+++ b/internal/server/template.html
@@ -4,47 +4,83 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ .Title }}</title>
-  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-  {{ $cssURL := "/static/github-markdown-dark.css" }}
+  <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+  {{ $cssChromaURL := "/static/chroma-github-dark.css" }}
+  {{ $cssMarkdownURL := "/static/github-markdown-dark.css" }}
   {{ if eq .Mode "light" }}
-  {{ $cssURL = "/static/github-markdown-light.css" }}
+    {{ $cssChromaURL = "/static/chroma-github-light.css" }}
+    {{ $cssMarkdownURL = "/static/github-markdown-light.css" }}
   {{ end }}
-  <link rel="stylesheet" href="{{ $cssURL }}" />
-  <style>
-    {{ if eq .Mode "dark" }}
-    body {
-      background-color: #0d1117;
-      color: #c9d1d9;
-    }
-    {{ end }}
+  <link rel="stylesheet" href="{{ $cssChromaURL }}" id="chroma-stylesheet" />
+  <link rel="stylesheet" href="{{ $cssMarkdownURL }}" id="markdown-stylesheet" />
 
+  <style>
     :root {
+      --background-dark: #0d1117;
+      --background-light: #ffffff;
+      --color-dark: #c9d1d9;
+      --color-light: #1f2328;
       --copy-icon-stroke-dark: #9198a1;
       --copy-icon-stroke-light: #59636e;
       --tick-icon-stroke-dark: #3fb950;
       --tick-icon-stroke-light: #3fb950;
     }
 
+    {{ if eq .Mode "dark" }}
+    body {
+      background-color: var(--background-dark);
+      color: var(--color-dark);
+    }
+    .copy-button svg.copy-icon {
+      stroke: var(--copy-icon-stroke-dark);
+      color: var(--copy-icon-stroke-dark);
+    }
+    .copy-button svg.tick-icon {
+      stroke: var(--tick-icon-stroke-dark);
+    }
+    {{ end }}
+
+    {{ if eq .Mode "light" }}
+    body {
+      background-color: var(--background-light);
+      color: var(--color-light);
+    }
+    .copy-button svg.copy-icon {
+      stroke: var(--copy-icon-stroke-light);
+    }
+    .copy-button svg.tick-icon {
+      stroke: var(--tick-icon-stroke-light);
+    }
+    {{ end }}
+
+    {{ if eq .Mode "auto" }}
     @media (prefers-color-scheme: dark) {
+      body {
+        background-color: var(--background-dark);
+        color: var(--color-dark);
+      }
       .copy-button svg.copy-icon {
         stroke: var(--copy-icon-stroke-dark);
         color: var(--copy-icon-stroke-dark);
       }
-
       .copy-button svg.tick-icon {
         stroke: var(--tick-icon-stroke-dark);
       }
     }
 
     @media (prefers-color-scheme: light) {
+      body {
+        background-color: var(--background-light);
+        color: var(--color-light);
+      }
       .copy-button svg.copy-icon {
         stroke: var(--copy-icon-stroke-light);
       }
-
       .copy-button svg.tick-icon {
         stroke: var(--tick-icon-stroke-light);
       }
     }
+    {{ end }}
 
     .markdown-body {
       box-sizing: border-box;
@@ -72,6 +108,29 @@
       }
     }
   </style>
+
+  {{ if eq .Mode "auto" }}
+  <script type="text/javascript">
+    function applyTheme(isDark) {
+      if (isDark) {
+        document.getElementById("chroma-stylesheet").href="/static/chroma-github-dark.css";
+        document.getElementById("markdown-stylesheet").href="/static/github-markdown-dark.css";
+      } else {
+        document.getElementById("chroma-stylesheet").href="/static/chroma-github-light.css";
+        document.getElementById("markdown-stylesheet").href="/static/github-markdown-light.css";
+      }
+    }
+
+    const prefersDarkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    // Apply on page load
+    applyTheme(prefersDarkQuery.matches);
+    // Change CSS when the theme changes
+    prefersDarkQuery.addEventListener("change", e => {
+      console.log("Theme changed, reload page!");
+      applyTheme(e.matches);
+    });
+  </script>
+  {{ end }}
 </head>
 
 <body>
@@ -145,14 +204,6 @@
         });
       });
     }
-
-    // Reload page if theme changes, so we can re-render it
-    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
-      console.log("Theme changed, reload page!");
-      // Can't just call loadMarkdown() here because we need to re-render
-      // the template server side
-      setTimeout(() => { location.reload(); }, 200);
-    });
 
     (async function() {
       await loadMarkdown();


### PR DESCRIPTION
- The auto logic is now all client based (i.e. no more re-rendering the whole file)
- Remove thiagokokada/dark-mode-go
- Fix for forced light/dark mode (e.g.: copy buttons used to have the wrong theme based in the user preference)