### PR TITLE
Heading list button

### DIFF
--- a/internal/server/static/directory-listing-light.css
+++ b/internal/server/static/directory-listing-light.css
@@ -38,6 +38,11 @@ body {
   border-color: #d0d7de;
   box-shadow: 0 8px 24px rgba(140, 149, 159, 0.2);
 }
+.headings-popover {
+  background: white;
+  border-color: #d0d7de;
+  box-shadow: 0 8px 24px rgba(140, 149, 159, 0.2);
+}
 .popover-header {
   border-bottom-color: #d0d7de;
 }
@@ -46,6 +51,17 @@ body {
 }
 .close-btn:hover {
   color: var(--background-light);
+}
+.btn-headings {
+  background: #f6f8fa;
+  color: #24292f;
+  border-color: #d0d7de;
+}
+.btn-headings:hover {
+  background: #eaeef2;
+}
+.heading-item:hover {
+  background: #f6f8fa;
 }
 .file-tree-popover .file-tree-item a:hover {
   background: #f6f8fa;

--- a/internal/server/static/directory-listing.css
+++ b/internal/server/static/directory-listing.css
@@ -3,6 +3,7 @@
   position: relative;
   display: flex;
   align-items: center;
+  gap: 8px;
 }
 
 .btn-browse,
@@ -22,14 +23,38 @@
   transition: background 0.2s ease;
 }
 
+.btn-headings {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: #21262d;
+  color: #c9d1d9;
+  border-radius: 6px;
+  text-decoration: none;
+  border: 1px solid #30363d;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 0.2s ease;
+}
+
 .btn-browse:hover,
 .btn-back:hover {
   background: #2ea043;
 }
 
+.btn-headings:hover {
+  background: #30363d;
+}
+
 .btn-browse svg,
 .btn-back svg {
   fill: white;
+}
+
+.btn-headings svg {
+  fill: currentColor;
 }
 
 /* Popover styles */
@@ -46,6 +71,47 @@
   z-index: 999;
   overflow: hidden;
 }
+
+.headings-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 260px;
+  max-height: 500px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(1, 4, 9, 0.8);
+  z-index: 999;
+  overflow: hidden;
+}
+
+.headings-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.heading-item {
+  display: block;
+  padding: 6px 8px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  font-size: 13px;
+  transition: background 0.15s ease;
+}
+
+.heading-item:hover {
+  background: #21262d;
+}
+
+.heading-level-1 { padding-left: 8px; }
+.heading-level-2 { padding-left: 20px; }
+.heading-level-3 { padding-left: 32px; }
+.heading-level-4 { padding-left: 44px; }
+.heading-level-5 { padding-left: 56px; }
+.heading-level-6 { padding-left: 68px; }
 
 .popover-header {
   display: flex;
@@ -252,6 +318,14 @@
 
 .popover-details.hidden {
   visibility: hidden;
+}
+
+.heading-details.hidden {
+  display: none;
+}
+
+.popover-details {
+  position: relative;
 }
 
 .files-popover {

--- a/internal/server/static/directory-listing.css
+++ b/internal/server/static/directory-listing.css
@@ -320,12 +320,17 @@
   visibility: hidden;
 }
 
-.heading-details.hidden {
-  display: none;
-}
-
 .popover-details {
   position: relative;
+}
+
+.heading-details.is-disabled > summary {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.heading-details.is-disabled > summary:hover {
+  background: inherit;
 }
 
 .files-popover {

--- a/internal/server/static/script.js
+++ b/internal/server/static/script.js
@@ -126,11 +126,7 @@
   }
 
   function slugify(text) {
-    return text
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)+/g, "");
+    return text.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)+/gm, "");
   }
 
   function buildHeadingsList() {
@@ -225,10 +221,15 @@
 
 // Popover functionality
 document.addEventListener("DOMContentLoaded", function () {
-  const popovers = [
-    document.getElementById("file-browser"),
-    document.getElementById("heading-list"),
-  ].filter(Boolean);
+  const popovers = [];
+  const fileBrowser = document.getElementById("file-browser");
+  if (fileBrowser) {
+    popovers.push(fileBrowser);
+  }
+  const headingList = document.getElementById("heading-list");
+  if (headingList) {
+    popovers.push(headingList);
+  }
 
   if (popovers.length === 0) {
     return;

--- a/internal/server/template.html
+++ b/internal/server/template.html
@@ -107,7 +107,7 @@
       </nav>
       <!-- Browse Files Button with Popover -->
       <div class="browse-button-container">
-        <details id="heading-list" class="popover-details heading-details hidden">
+        <details id="heading-list" class="popover-details heading-details">
           <summary class="btn-headings">
             <svg class="heading-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
               <path d="M2 3.75C2 2.784 2.784 2 3.75 2h8.5C13.216 2 14 2.784 14 3.75v8.5c0 .966-.784 1.75-1.75 1.75h-8.5C2.784 14 2 13.216 2 12.25v-8.5Zm1.75-.25a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25h-8.5Zm1 2.25a.75.75 0 0 1 .75-.75h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1-.75-.75Zm0 3a.75.75 0 0 1 .75-.75h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1-.75-.75Zm0 3a.75.75 0 0 1 .75-.75h3.5a.75.75 0 0 1 0 1.5h-3.5a.75.75 0 0 1-.75-.75Z"></path>

--- a/internal/server/template.html
+++ b/internal/server/template.html
@@ -120,8 +120,6 @@
               <h3>Headings</h3>
 
               <button type="button" class="close-btn" onclick="this.closest('details').removeAttribute('open')">×</button>
-              <!-- hide close-btn since it doesn't work without JS -->
-              <noscript><style>.close-btn { display: none !important; }</style></noscript>
             </div>
 
             <div class="popover-body">
@@ -129,6 +127,9 @@
             </div>
           </div>
         </details>
+        <!-- hide headings since it doesn't work without JS -->
+        <noscript><style>#heading-list { display: none !important; }</style></noscript>
+
         <details id="file-browser" class="popover-details {{if not .ShowBrowseButton}}hidden{{end}}">
           <summary class="btn-browse">
             <svg class="file-icon" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
@@ -141,9 +142,9 @@
             <div class="popover-header">
               <h3>Files</h3>
 
-              <button type="button" class="close-btn" onclick="this.closest('details').removeAttribute('open')">×</button>
+              <button type="button" class="close-btn" id="files-close-btn" onclick="this.closest('details').removeAttribute('open')">×</button>
               <!-- hide close-btn since it doesn't work without JS -->
-              <noscript><style>.close-btn { display: none !important; }</style></noscript>
+              <noscript><style>#files-close-btn { display: none !important; }</style></noscript>
             </div>
 
             <div class="popover-body">

--- a/internal/server/template.html
+++ b/internal/server/template.html
@@ -107,6 +107,28 @@
       </nav>
       <!-- Browse Files Button with Popover -->
       <div class="browse-button-container">
+        <details id="heading-list" class="popover-details heading-details hidden">
+          <summary class="btn-headings">
+            <svg class="heading-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+              <path d="M2 3.75C2 2.784 2.784 2 3.75 2h8.5C13.216 2 14 2.784 14 3.75v8.5c0 .966-.784 1.75-1.75 1.75h-8.5C2.784 14 2 13.216 2 12.25v-8.5Zm1.75-.25a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25h-8.5Zm1 2.25a.75.75 0 0 1 .75-.75h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1-.75-.75Zm0 3a.75.75 0 0 1 .75-.75h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1-.75-.75Zm0 3a.75.75 0 0 1 .75-.75h3.5a.75.75 0 0 1 0 1.5h-3.5a.75.75 0 0 1-.75-.75Z"></path>
+            </svg>
+            Headings
+          </summary>
+
+          <div id="headings-popover" class="headings-popover">
+            <div class="popover-header">
+              <h3>Headings</h3>
+
+              <button type="button" class="close-btn" onclick="this.closest('details').removeAttribute('open')">×</button>
+              <!-- hide close-btn since it doesn't work without JS -->
+              <noscript><style>.close-btn { display: none !important; }</style></noscript>
+            </div>
+
+            <div class="popover-body">
+              <div id="headings-tree" class="headings-tree"></div>
+            </div>
+          </div>
+        </details>
         <details id="file-browser" class="popover-details {{if not .ShowBrowseButton}}hidden{{end}}">
           <summary class="btn-browse">
             <svg class="file-icon" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">


### PR DESCRIPTION
# Summary
Add a headings list popover button for markdown views, shown next to Browse Files in directory mode.

<img width="594" height="426" alt="my_screenshot" src="https://github.com/user-attachments/assets/b0f6bd1d-14bd-4759-b591-53dc898ff1d8" />


# Changes
- Add a Headings button and popover UI to the template.
- Build and update a headings list in the client script (including on live reload).
- Add dark/light theme styles for the headings popover.
