### PR TITLE
Fix directory watching with broken symlinks

### DIFF
--- a/internal/server/directory_handler.go
+++ b/internal/server/directory_handler.go
@@ -30,7 +30,12 @@ func handleDirectoryMode(w http.ResponseWriter, r *http.Request, param *Param, w
 		return
 	}
 
-	currentHostPath := directoryHostPath(param.DirectoryPath, currentURLPath)
+	var currentHostPath string
+	if info.IsDir() {
+		currentHostPath = directoryHostPath(param.DirectoryPath, currentURLPath)
+	} else {
+		currentHostPath = directoryHostPath(param.DirectoryPath, getParentPath(currentURLPath))
+	}
 
 	err = watcher.AddDirectory(currentHostPath)
 	if err != nil {

--- a/internal/server/directory_handler_test.go
+++ b/internal/server/directory_handler_test.go
@@ -219,6 +219,32 @@ func Test404ErrorRendering(t *testing.T) {
 	}
 }
 
+func TestDirectoryHostPathUsesParentDirectoryForFileWatches(t *testing.T) {
+	filePath := filepath.Join(testDataDir, "images", "dinotocat.png")
+	info, err := os.Stat(filePath)
+	assert.Nil(t, err)
+
+	got := directoryHostPath(testDataDir, "images/dinotocat.png")
+	if !info.IsDir() {
+		got = directoryHostPath(testDataDir, getParentPath("images/dinotocat.png"))
+	}
+
+	assert.Equal(t, got, filepath.Join(testDataDir, "images"))
+}
+
+func TestDirectoryHostPathUsesCurrentDirectoryForDirectoryWatches(t *testing.T) {
+	dirPath := filepath.Join(testDataDir, "subdir")
+	info, err := os.Stat(dirPath)
+	assert.Nil(t, err)
+
+	got := directoryHostPath(testDataDir, "subdir")
+	if !info.IsDir() {
+		got = directoryHostPath(testDataDir, getParentPath("subdir"))
+	}
+
+	assert.Equal(t, got, filepath.Join(testDataDir, "subdir"))
+}
+
 func TestGenerateFileTree(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,12 +64,8 @@ func resolveFileMode(param *Param) (string, string, error) {
 	info, statErr := os.Stat(inputPath)
 	isDir := statErr == nil && info.IsDir()
 
-	if param.DirectoryListing {
-		if isDir {
-			return setupDirectoryMode(param, inputPath)
-		}
-
-		return setupDirectoryMode(param, filepath.Dir(inputPath))
+	if isDir && param.DirectoryListing {
+		return setupDirectoryMode(param, inputPath)
 	}
 
 	return setupFileMode(param, inputPath)
@@ -130,7 +126,7 @@ func (server *Server) Serve(param *Param) error {
 		return fmt.Errorf("failed to get static subdirectory: %w", err)
 	}
 
-	watchTarget := watcherTarget(filename, dir, param)
+	watchTarget := watcherTarget(dir)
 
 	watcher := initWatcher(watchTarget, param)
 	defer watcher.Close()
@@ -177,11 +173,7 @@ func (server *Server) Serve(param *Param) error {
 	return nil
 }
 
-func watcherTarget(filename, dir string, param *Param) string {
-	if !param.IsDirectoryMode && filename != "" {
-		return filename
-	}
-
+func watcherTarget(dir string) string {
 	return dir
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -132,10 +132,7 @@ func (server *Server) Serve(param *Param) error {
 
 	watchTarget := watcherTarget(filename, dir, param)
 
-	watcher, err := initWatcher(watchTarget, param)
-	if err != nil {
-		return fmt.Errorf("error while file watcher init for %s: %w", watchTarget, err)
-	}
+	watcher := initWatcher(watchTarget, param)
 	defer watcher.Close()
 
 	serveMux := http.NewServeMux()
@@ -188,16 +185,17 @@ func watcherTarget(filename, dir string, param *Param) string {
 	return dir
 }
 
-func initWatcher(watchTarget string, param *Param) (*watcher.Watcher, error) {
+func initWatcher(watchTarget string, param *Param) *watcher.Watcher {
 	w, err := watcher.Init(watchTarget)
 	if err == nil {
-		return w, nil
+		return w
 	}
 
 	slog.Warn("File watcher unavailable, live reload disabled", "path", watchTarget, "error", err)
+
 	param.Reload = false
 
-	return watcher.NewDisabled(), nil
+	return watcher.NewDisabled()
 }
 
 func handler(filename string, param *Param, handler http.Handler, watcher *watcher.Watcher) http.Handler {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,8 +64,12 @@ func resolveFileMode(param *Param) (string, string, error) {
 	info, statErr := os.Stat(inputPath)
 	isDir := statErr == nil && info.IsDir()
 
-	if isDir && param.DirectoryListing {
-		return setupDirectoryMode(param, inputPath)
+	if param.DirectoryListing {
+		if isDir {
+			return setupDirectoryMode(param, inputPath)
+		}
+
+		return setupDirectoryMode(param, filepath.Dir(inputPath))
 	}
 
 	return setupFileMode(param, inputPath)
@@ -126,9 +130,11 @@ func (server *Server) Serve(param *Param) error {
 		return fmt.Errorf("failed to get static subdirectory: %w", err)
 	}
 
-	watcher, err := watcher.Init(dir)
+	watchTarget := watcherTarget(filename, dir, param)
+
+	watcher, err := watcher.Init(watchTarget)
 	if err != nil {
-		return fmt.Errorf("error while file watcher init: %w", err)
+		return fmt.Errorf("error while file watcher init for %s: %w", watchTarget, err)
 	}
 	defer watcher.Close()
 
@@ -172,6 +178,14 @@ func (server *Server) Serve(param *Param) error {
 	}
 
 	return nil
+}
+
+func watcherTarget(filename, dir string, param *Param) string {
+	if !param.IsDirectoryMode && filename != "" {
+		return filename
+	}
+
+	return dir
 }
 
 func handler(filename string, param *Param, handler http.Handler, watcher *watcher.Watcher) http.Handler {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -132,7 +132,7 @@ func (server *Server) Serve(param *Param) error {
 
 	watchTarget := watcherTarget(filename, dir, param)
 
-	watcher, err := watcher.Init(watchTarget)
+	watcher, err := initWatcher(watchTarget, param)
 	if err != nil {
 		return fmt.Errorf("error while file watcher init for %s: %w", watchTarget, err)
 	}
@@ -186,6 +186,18 @@ func watcherTarget(filename, dir string, param *Param) string {
 	}
 
 	return dir
+}
+
+func initWatcher(watchTarget string, param *Param) (*watcher.Watcher, error) {
+	w, err := watcher.Init(watchTarget)
+	if err == nil {
+		return w, nil
+	}
+
+	slog.Warn("File watcher unavailable, live reload disabled", "path", watchTarget, "error", err)
+	param.Reload = false
+
+	return watcher.NewDisabled(), nil
 }
 
 func handler(filename string, param *Param, handler http.Handler, watcher *watcher.Watcher) http.Handler {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -316,3 +316,20 @@ func TestWatcherTargetDirectoryModeUsesDirectory(t *testing.T) {
 
 	assert.Equal(t, target, ".")
 }
+
+func TestInitWatcherDisablesReloadOnInitError(t *testing.T) {
+	param := &Param{
+		Reload: true,
+	}
+
+	w, err := initWatcher(filepath.Join(t.TempDir(), "missing"), param)
+	assert.Nil(t, err)
+	assert.NotNil(t, w)
+	assert.False(t, param.Reload)
+
+	err = w.AddDirectory("anywhere")
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -281,42 +281,6 @@ func TestWrapHandler(t *testing.T) {
 	assert.Equal(t, res.StatusCode, http.StatusOK)
 }
 
-func TestResolveFileModeDirectoryListingUsesParentDirectoryForFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "screenshot.png")
-	err := os.WriteFile(filePath, []byte("png"), 0o600)
-	assert.Nil(t, err)
-
-	param := &Param{
-		Filename:         filePath,
-		DirectoryListing: true,
-	}
-
-	filename, dir, err := resolveFileMode(param)
-	assert.Nil(t, err)
-
-	assert.Equal(t, filename, "")
-	assert.Equal(t, dir, tmpDir)
-	assert.True(t, param.IsDirectoryMode)
-	assert.Equal(t, param.DirectoryPath, tmpDir)
-}
-
-func TestWatcherTargetSingleFileModeUsesFilename(t *testing.T) {
-	param := &Param{}
-
-	target := watcherTarget("README.md", ".", param)
-
-	assert.Equal(t, target, "README.md")
-}
-
-func TestWatcherTargetDirectoryModeUsesDirectory(t *testing.T) {
-	param := &Param{IsDirectoryMode: true}
-
-	target := watcherTarget("README.md", ".", param)
-
-	assert.Equal(t, target, ".")
-}
-
 func TestInitWatcherDisablesReloadOnInitError(t *testing.T) {
 	param := &Param{
 		Reload: true,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -322,12 +322,11 @@ func TestInitWatcherDisablesReloadOnInitError(t *testing.T) {
 		Reload: true,
 	}
 
-	w, err := initWatcher(filepath.Join(t.TempDir(), "missing"), param)
-	assert.Nil(t, err)
+	w := initWatcher(filepath.Join(t.TempDir(), "missing"), param)
 	assert.NotNil(t, w)
 	assert.False(t, param.Reload)
 
-	err = w.AddDirectory("anywhere")
+	err := w.AddDirectory("anywhere")
 	assert.Nil(t, err)
 
 	err = w.Close()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -280,3 +280,39 @@ func TestWrapHandler(t *testing.T) {
 
 	assert.Equal(t, res.StatusCode, http.StatusOK)
 }
+
+func TestResolveFileModeDirectoryListingUsesParentDirectoryForFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "screenshot.png")
+	err := os.WriteFile(filePath, []byte("png"), 0o600)
+	assert.Nil(t, err)
+
+	param := &Param{
+		Filename:         filePath,
+		DirectoryListing: true,
+	}
+
+	filename, dir, err := resolveFileMode(param)
+	assert.Nil(t, err)
+
+	assert.Equal(t, filename, "")
+	assert.Equal(t, dir, tmpDir)
+	assert.True(t, param.IsDirectoryMode)
+	assert.Equal(t, param.DirectoryPath, tmpDir)
+}
+
+func TestWatcherTargetSingleFileModeUsesFilename(t *testing.T) {
+	param := &Param{}
+
+	target := watcherTarget("README.md", ".", param)
+
+	assert.Equal(t, target, "README.md")
+}
+
+func TestWatcherTargetDirectoryModeUsesDirectory(t *testing.T) {
+	param := &Param{IsDirectoryMode: true}
+
+	target := watcherTarget("README.md", ".", param)
+
+	assert.Equal(t, target, ".")
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -56,6 +56,14 @@ func Init(dir string) (*Watcher, error) {
 
 	err = watcher.AddDirectory(dir)
 	if err != nil {
+		closeErr := fsWatcher.Close()
+		if closeErr != nil {
+			return nil, fmt.Errorf(
+				"close watcher after init failure: %w",
+				errors.Join(closeErr, err),
+			)
+		}
+
 		return nil, err
 	}
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -115,35 +115,7 @@ func (w *Watcher) Watch() {
 				continue
 			}
 
-			path := event.Name
-			op := event.Op
-			base := filepath.Base(path)
-
-			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-				if re.MatchString(base) {
-					slog.Debug("FS event from ignored pattern", "op", op, "path", path)
-
-					continue
-				}
-
-				if !mu.TryLock() {
-					slog.Debug("FS event debounced", "op", op, "path", path)
-
-					continue
-				}
-
-				slog.Debug("FS event", "op", op, "path", path)
-
-				go func() {
-					defer mu.Unlock()
-
-					slog.Info("Change detected, refreshing", "path", event.Name)
-
-					w.MessageCh <- ReloadMessage
-
-					time.Sleep(lockTime)
-				}()
-			}
+			w.handleEvent(event, re, &mu)
 		case err := <-w.watcher.Errors:
 			slog.Error("FS watcher error", "error", err)
 
@@ -152,4 +124,38 @@ func (w *Watcher) Watch() {
 			return
 		}
 	}
+}
+
+func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, mu *sync.Mutex) {
+	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) {
+		return
+	}
+
+	path := event.Name
+	op := event.Op
+	base := filepath.Base(path)
+
+	if re.MatchString(base) {
+		slog.Debug("FS event from ignored pattern", "op", op, "path", path)
+
+		return
+	}
+
+	if !mu.TryLock() {
+		slog.Debug("FS event debounced", "op", op, "path", path)
+
+		return
+	}
+
+	slog.Debug("FS event", "op", op, "path", path)
+
+	go func() {
+		defer mu.Unlock()
+
+		slog.Info("Change detected, refreshing", "path", event.Name)
+
+		w.MessageCh <- ReloadMessage
+
+		time.Sleep(lockTime)
+	}()
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -31,6 +31,14 @@ type Watcher struct {
 	watchedDirs sync.Map
 }
 
+func NewDisabled() *Watcher {
+	return &Watcher{
+		DoneCh:    make(chan struct{}),
+		ErrorCh:   make(chan error),
+		MessageCh: make(chan []byte, 1),
+	}
+}
+
 func Init(dir string) (*Watcher, error) {
 	fsWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -55,6 +63,10 @@ func Init(dir string) (*Watcher, error) {
 }
 
 func (w *Watcher) Close() error {
+	if w == nil || w.watcher == nil {
+		return nil
+	}
+
 	err := w.watcher.Close()
 	if err != nil {
 		return fmt.Errorf("error during watcher close call: %w", err)
@@ -66,6 +78,10 @@ func (w *Watcher) Close() error {
 func (w *Watcher) AddDirectory(dir string) error {
 	if w == nil {
 		return ErrWatcherNotInitialized
+	}
+
+	if w.watcher == nil {
+		return nil
 	}
 
 	if _, loaded := w.watchedDirs.LoadOrStore(dir, true); loaded {
@@ -85,6 +101,10 @@ func (w *Watcher) AddDirectory(dir string) error {
 }
 
 func (w *Watcher) Watch() {
+	if w == nil || w.watcher == nil {
+		return
+	}
+
 	re := regexp.MustCompile(ignorePattern)
 	mu := sync.Mutex{}
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -90,6 +90,7 @@ func (w *Watcher) AddDirectory(dir string) error {
 
 	err := w.watcher.Add(dir)
 	if err != nil {
+		// Roll back the map if Add failed
 		w.watchedDirs.Delete(dir)
 
 		return fmt.Errorf("failed to add dir %s to watcher: %w", dir, err)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -74,7 +74,6 @@ func (w *Watcher) AddDirectory(dir string) error {
 
 	err := w.watcher.Add(dir)
 	if err != nil {
-		// Roll back the map if Add failed
 		w.watchedDirs.Delete(dir)
 
 		return fmt.Errorf("failed to add dir %s to watcher: %w", dir, err)

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -135,3 +135,11 @@ func TestWatch_DebounceLogic(t *testing.T) {
 	assert.True(t, counter.Load() > 0)
 	assert.True(t, counter.Load() <= 5)
 }
+
+func TestInit_ReturnsErrorForMissingPath(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing")
+
+	w, err := Init(missingPath)
+	assert.Nil(t, w)
+	assert.True(t, err != nil)
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -135,33 +135,3 @@ func TestWatch_DebounceLogic(t *testing.T) {
 	assert.True(t, counter.Load() > 0)
 	assert.True(t, counter.Load() <= 5)
 }
-
-func TestInit_FileWatchIgnoresBrokenSiblingSymlink(t *testing.T) {
-	dir, cleanup := setupTestDir(t)
-	defer cleanup()
-
-	filePath := filepath.Join(dir, "test.md")
-	err := os.WriteFile(filePath, []byte("initial"), 0o600)
-	assert.Nil(t, err)
-
-	err = os.Symlink(filepath.Join(dir, "missing-target"), filepath.Join(dir, "broken-link"))
-	assert.Nil(t, err)
-
-	w, err := Init(filePath)
-	assert.Nil(t, err)
-
-	defer w.Close()
-
-	go w.Watch()
-
-	time.Sleep(50 * time.Millisecond)
-
-	err = os.WriteFile(filePath, []byte("updated"), 0o600)
-	assert.Nil(t, err)
-
-	select {
-	case <-w.MessageCh:
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout waiting for file write event with broken sibling symlink present")
-	}
-}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -135,3 +135,32 @@ func TestWatch_DebounceLogic(t *testing.T) {
 	assert.True(t, counter.Load() > 0)
 	assert.True(t, counter.Load() <= 5)
 }
+
+func TestInit_FileWatchIgnoresBrokenSiblingSymlink(t *testing.T) {
+	dir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	filePath := filepath.Join(dir, "test.md")
+	err := os.WriteFile(filePath, []byte("initial"), 0o600)
+	assert.Nil(t, err)
+
+	err = os.Symlink(filepath.Join(dir, "missing-target"), filepath.Join(dir, "broken-link"))
+	assert.Nil(t, err)
+
+	w, err := Init(filePath)
+	assert.Nil(t, err)
+	defer w.Close()
+
+	go w.Watch()
+
+	time.Sleep(50 * time.Millisecond)
+
+	err = os.WriteFile(filePath, []byte("updated"), 0o600)
+	assert.Nil(t, err)
+
+	select {
+	case <-w.MessageCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for file write event with broken sibling symlink present")
+	}
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -149,6 +149,7 @@ func TestInit_FileWatchIgnoresBrokenSiblingSymlink(t *testing.T) {
 
 	w, err := Init(filePath)
 	assert.Nil(t, err)
+
 	defer w.Close()
 
 	go w.Watch()


### PR DESCRIPTION
- Handle errors in the watcher, so now it will disable the watcher if it encounters an error in the startup instead of failing.
- Only add directories in `--directory-listing` mode, not files.