### PR TITLE
Add interactive pan/zoom and reset for mermaid diagrams

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -257,6 +257,32 @@ func TestMdHandlerDirectoryModeRejectsEscapingPaths(t *testing.T) {
 	}
 }
 
+func TestMdHandlerRendersMermaid(t *testing.T) {
+	filename := "../../testdata/mermaid.md"
+
+	req := httptest.NewRequest(http.MethodGet, "/__/md", nil)
+	rec := httptest.NewRecorder()
+
+	mdHandler(filename, &Param{}).ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, res.StatusCode, http.StatusOK)
+
+	body, err := io.ReadAll(res.Body)
+	assert.Nil(t, err)
+
+	var payload mdResponseJSON
+
+	err = json.Unmarshal(body, &payload)
+	assert.Nil(t, err)
+
+	// mermaid code blocks must carry class="language-mermaid" for the
+	// client-side pan/zoom setup (setupMermaidPanZoom) to activate
+	assert.True(t, strings.Contains(payload.HTML, `class="language-mermaid"`))
+}
+
 func TestWrapHandler(t *testing.T) {
 	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w, "Hello")

--- a/internal/server/static/script.js
+++ b/internal/server/static/script.js
@@ -5,21 +5,229 @@
   "use strict";
 
   const mermaidQuery = "code.language-mermaid";
+  const mermaidMinScale = 0.2;
+  const mermaidMaxScale = 5;
+  const mermaidZoomInFactor = 1.1;
+  const mermaidZoomOutFactor = 0.9;
+  const mermaidOverlayPadding = 64;
   const geoJSONQuery = "code.language-geojson";
   const topoJSONQuery = "code.language-topojson";
   const mapQuery = `${geoJSONQuery}, ${topoJSONQuery}`;
   const copyIcon = `<svg class="copy-icon" aria-hidden="true" fill="none" height="18" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="18" style="color:"currentColor";"><path d="M8 17.929H6c-1.105 0-2-.912-2-2.036V5.036C4 3.91 4.895 3 6 3h8c1.105 0 2 .911 2 2.036v1.866m-6 .17h8c1.105 0 2 .91 2 2.035v10.857C20 21.09 19.105 22 18 22h-8c-1.105 0-2-.911-2-2.036V9.107c0-1.124.895-2.036 2-2.036z"></path></svg>`;
   const tickIcon = `<svg class="tick-icon" aria-hidden="true" fill="none" height="18" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="18" style="color: "currentColor";"><path d="M5 13l4 4L19 7"></path></svg>`;
+  const expandIcon = `<svg class="expand-icon" aria-hidden="true" viewBox="0 0 1792 1792" width="14" height="14" fill="currentColor"><path d="M883 1056q0 13-10 23l-332 332 144 144q19 19 19 45t-19 45-45 19h-448q-26 0-45-19t-19-45v-448q0-26 19-45t45-19 45 19l144 144 332-332q10-10 23-10t23 10l114 114q10 10 10 23zm781-864v448q0 26-19 45t-45 19-45-19l-144-144-332 332q-10 10-23 10t-23-10l-114-114q-10-10-10-23t10-23l332-332-144-144q-19-19-19-45t19-45 45-19h448q26 0 45 19t19 45z"></path></svg>`;
   let diagramMediaQuery;
+  let overlayCleanup;
+  let overlayEl;
 
-  function loadMermaid(isLight) {
+  async function loadMermaid(isLight) {
     const theme = (
       isLight
       ? "default"
       : "dark"
     );
     window.mermaid.initialize({startOnLoad: false, theme});
-    window.mermaid.run({querySelector: mermaidQuery});
+    await window.mermaid.run({querySelector: mermaidQuery});
+    setupMermaidPanZoom();
+  }
+
+  function attachPanZoom(element, svg) {
+    const state = {dragging: false, lastX: 0, lastY: 0, scale: 1, tx: 0, ty: 0};
+    const applyTransform = () => {
+      svg.style.transform = `translate(${state.tx}px, ${state.ty}px) scale(${state.scale})`;
+    };
+    const onWheel = (e) => {
+      const rect = element.getBoundingClientRect();
+      const factor = (
+        e.deltaY < 0
+        ? mermaidZoomInFactor
+        : mermaidZoomOutFactor
+      );
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const newScale = Math.max(mermaidMinScale, Math.min(mermaidMaxScale, state.scale * factor));
+      e.preventDefault();
+      if (newScale === state.scale) {
+        return;
+      }
+      state.tx = mx - (mx - state.tx) * (newScale / state.scale);
+      state.ty = my - (my - state.ty) * (newScale / state.scale);
+      state.scale = newScale;
+      applyTransform();
+    };
+    const onPointerDown = (e) => {
+      if (e.button !== 0) {
+        return;
+      }
+      state.dragging = true;
+      state.lastX = e.clientX;
+      state.lastY = e.clientY;
+      element.style.cursor = "grabbing";
+      element.setPointerCapture(e.pointerId);
+      e.preventDefault();
+    };
+    const onPointerMove = (e) => {
+      if (!state.dragging) {
+        return;
+      }
+      state.tx += e.clientX - state.lastX;
+      state.ty += e.clientY - state.lastY;
+      state.lastX = e.clientX;
+      state.lastY = e.clientY;
+      applyTransform();
+    };
+    const onPointerUp = () => {
+      if (!state.dragging) {
+        return;
+      }
+      state.dragging = false;
+      element.style.cursor = "grab";
+    };
+    const detach = () => {
+      element.removeEventListener("wheel", onWheel);
+      element.removeEventListener("pointerdown", onPointerDown);
+      element.removeEventListener("pointermove", onPointerMove);
+      element.removeEventListener("pointerup", onPointerUp);
+      element.removeEventListener("pointercancel", onPointerUp);
+    };
+    element.addEventListener("wheel", onWheel, {passive: false});
+    element.addEventListener("pointerdown", onPointerDown);
+    element.addEventListener("pointermove", onPointerMove);
+    element.addEventListener("pointerup", onPointerUp);
+    element.addEventListener("pointercancel", onPointerUp);
+    return {applyTransform, detach, state};
+  }
+
+  function openMermaidOverlay(originalSvg) {
+    if (overlayCleanup) {
+      overlayCleanup();
+    }
+    if (!overlayEl) {
+      overlayEl = document.createElement("div");
+      overlayEl.classList.add("mermaid-overlay");
+      overlayEl.setAttribute("role", "dialog");
+      overlayEl.setAttribute("aria-modal", "true");
+      overlayEl.setAttribute("aria-label", "Diagram fullscreen view");
+      document.body.appendChild(overlayEl);
+    }
+    const svgClone = originalSvg.cloneNode(true);
+    svgClone.removeAttribute("data-panzoom");
+    svgClone.style.transform = "";
+    svgClone.style.transformOrigin = "0 0";
+    svgClone.style.display = "block";
+    const inner = document.createElement("div");
+    inner.classList.add("mermaid-overlay-inner");
+    inner.appendChild(svgClone);
+    const closeBtn = document.createElement("button");
+    closeBtn.setAttribute("type", "button");
+    closeBtn.classList.add("mermaid-overlay-close");
+    closeBtn.setAttribute("aria-label", "Close fullscreen view");
+    closeBtn.textContent = "×";
+    const resetBtn = document.createElement("button");
+    resetBtn.setAttribute("type", "button");
+    resetBtn.classList.add("mermaid-reset-btn");
+    resetBtn.setAttribute("aria-label", "Reset diagram view");
+    resetBtn.textContent = "Reset";
+    overlayEl.innerHTML = "";
+    overlayEl.appendChild(inner);
+    overlayEl.appendChild(closeBtn);
+    overlayEl.appendChild(resetBtn);
+    const panZoom = attachPanZoom(inner, svgClone);
+    document.body.style.overflow = "hidden";
+    overlayEl.classList.add("is-open");
+    const innerRect = inner.getBoundingClientRect();
+    const svgRect = svgClone.getBoundingClientRect();
+    if (svgRect.width > 0 && svgRect.height > 0) {
+      const fitScale = Math.min(
+        1,
+        (innerRect.width - mermaidOverlayPadding) / svgRect.width,
+        (innerRect.height - mermaidOverlayPadding) / svgRect.height
+      );
+      panZoom.state.scale = fitScale;
+      panZoom.state.tx = (innerRect.width - svgRect.width * fitScale) / 2;
+      panZoom.state.ty = (innerRect.height - svgRect.height * fitScale) / 2;
+      panZoom.applyTransform();
+    }
+    const initScale = panZoom.state.scale;
+    const initTx = panZoom.state.tx;
+    const initTy = panZoom.state.ty;
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") {
+        closeOverlay();
+      }
+    };
+    const closeOverlay = () => {
+      overlayEl.classList.remove("is-open");
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", onKeyDown);
+      panZoom.detach();
+      overlayCleanup = null;
+    };
+    resetBtn.addEventListener("click", () => {
+      panZoom.state.scale = initScale;
+      panZoom.state.tx = initTx;
+      panZoom.state.ty = initTy;
+      panZoom.applyTransform();
+    });
+    closeBtn.addEventListener("click", closeOverlay);
+    document.addEventListener("keydown", onKeyDown);
+    overlayCleanup = closeOverlay;
+  }
+
+  function setupMermaidPanZoom() {
+    document.querySelectorAll(mermaidQuery).forEach((element) => {
+      const svg = element.querySelector("svg");
+      if (!svg || svg.hasAttribute("data-panzoom")) {
+        return;
+      }
+      const pre = element.closest("pre");
+      const oldResetBtn = (
+        pre
+        ? pre.querySelector(".mermaid-reset-btn")
+        : null
+      );
+      const oldExpandBtn = (
+        pre
+        ? pre.querySelector(".mermaid-expand-btn")
+        : null
+      );
+      const panZoom = attachPanZoom(element, svg);
+      const resetBtn = document.createElement("button");
+      const expandBtn = document.createElement("button");
+      svg.setAttribute("data-panzoom", "true");
+      svg.style.transformOrigin = "0 0";
+      svg.style.display = "block";
+      if (pre) {
+        pre.classList.add("diagram-mermaid-pre");
+        pre.style.position = "relative";
+      }
+      element.classList.add("diagram-mermaid-code");
+      resetBtn.setAttribute("type", "button");
+      resetBtn.classList.add("mermaid-reset-btn");
+      resetBtn.setAttribute("aria-label", "Reset diagram view");
+      resetBtn.textContent = "Reset";
+      resetBtn.addEventListener("click", () => {
+        panZoom.state.scale = 1;
+        panZoom.state.tx = 0;
+        panZoom.state.ty = 0;
+        panZoom.applyTransform();
+      });
+      expandBtn.setAttribute("type", "button");
+      expandBtn.classList.add("mermaid-expand-btn");
+      expandBtn.setAttribute("aria-label", "Expand diagram to full screen");
+      expandBtn.innerHTML = expandIcon;
+      expandBtn.addEventListener("click", () => openMermaidOverlay(svg));
+      if (oldResetBtn) {
+        oldResetBtn.remove();
+      }
+      if (oldExpandBtn) {
+        oldExpandBtn.remove();
+      }
+      if (pre) {
+        pre.appendChild(resetBtn);
+        pre.appendChild(expandBtn);
+      }
+    });
   }
 
   function saveOriginalData(query) {
@@ -201,34 +409,32 @@
     }).catch(console.error);
   }
 
-  function initMermaid() {
+  async function initMermaid() {
     // Workaround issue with MermaidJS that doesn't allow changing theme on
     // re-initialization
     // https://github.com/mermaid-js/mermaid/issues/1945#issuecomment-1661264708
     saveOriginalData(mermaidQuery).catch(console.error);
 
     if (window.Param.mode === "dark") {
-      loadMermaid(false);
+      await loadMermaid(false);
     } else if (window.Param.mode === "light") {
-      loadMermaid(true);
+      await loadMermaid(true);
     } else {
       if (!diagramMediaQuery) {
         diagramMediaQuery = window.matchMedia("(prefers-color-scheme: light)");
       }
-      loadMermaid(diagramMediaQuery.matches);
+      await loadMermaid(diagramMediaQuery.matches);
       if (!diagramMediaQuery.codexListenerAdded) {
         diagramMediaQuery.addEventListener("change", (e) => {
-          resetProcessed(mermaidQuery).then(() => {
-            loadMermaid(e.matches);
-          }).catch(console.error);
+          resetProcessed(mermaidQuery).then(() => loadMermaid(e.matches)).catch(console.error);
         });
         diagramMediaQuery.codexListenerAdded = true;
       }
     }
   }
 
-  function renderDiagrams() {
-    initMermaid();
+  async function renderDiagrams() {
+    await initMermaid();
     document.querySelectorAll(mapQuery).forEach((element) => {
       element.removeAttribute("data-processed");
     });
@@ -247,7 +453,7 @@
 
     updateHeadingsList(result.headings_html, result.has_headings);
 
-    renderDiagrams();
+    await renderDiagrams();
     await typesetMathJax();
     addCopyButtons();
   }

--- a/internal/server/static/script.js
+++ b/internal/server/static/script.js
@@ -30,7 +30,7 @@
     try {
       await window.mermaid.run({querySelector: mermaidQuery});
     } catch (error) {
-      console.error(error);
+      console.error("Failed to render Mermaid diagrams:", error);
     }
     setupMermaidPanZoom();
   }

--- a/internal/server/static/script.js
+++ b/internal/server/static/script.js
@@ -27,7 +27,11 @@
       : "dark"
     );
     window.mermaid.initialize({startOnLoad: false, theme});
-    await window.mermaid.run({querySelector: mermaidQuery});
+    try {
+      await window.mermaid.run({querySelector: mermaidQuery});
+    } catch (error) {
+      console.error(error);
+    }
     setupMermaidPanZoom();
   }
 

--- a/internal/server/template.html
+++ b/internal/server/template.html
@@ -75,6 +75,144 @@
       cursor: pointer;
     }
 
+    .markdown-body pre.diagram-mermaid-pre {
+      padding: 0;
+      overflow: hidden;
+    }
+
+    .markdown-body pre.diagram-mermaid-pre > code.diagram-mermaid-code {
+      display: block;
+      padding: 0;
+      background: transparent;
+      overflow: hidden;
+      cursor: grab;
+      touch-action: none;
+      user-select: none;
+    }
+
+    .mermaid-reset-btn {
+      background-color: transparent;
+      border: 1px solid #30363d;
+      bottom: 8px;
+      border-radius: 5px;
+      color: #9198a1;
+      cursor: pointer;
+      font-size: 12px;
+      line-height: 1.4;
+      padding: 3px 8px;
+      position: absolute;
+      right: 8px;
+      transition: border-color 0.2s ease, color 0.2s ease;
+      z-index: 1000;
+    }
+
+    .mermaid-reset-btn:hover {
+      border-color: #6e7681;
+      color: #c9d1d9;
+    }
+
+    .mermaid-expand-btn {
+      background-color: transparent;
+      border: none;
+      cursor: pointer;
+      left: 8px;
+      padding: 5px;
+      position: absolute;
+      top: 8px;
+      z-index: 1000;
+    }
+
+    .mermaid-expand-btn svg {
+      display: block;
+      fill: #9198a1;
+      transition: fill 0.2s ease;
+    }
+
+    .mermaid-expand-btn:hover svg {
+      fill: #c9d1d9;
+    }
+
+    .mermaid-overlay {
+      background-color: rgba(0, 0, 0, 0.85);
+      display: none;
+      inset: 0;
+      position: fixed;
+      z-index: 10000;
+    }
+
+    .mermaid-overlay.is-open {
+      display: block;
+    }
+
+    .mermaid-overlay-inner {
+      cursor: grab;
+      height: 100%;
+      overflow: hidden;
+      touch-action: none;
+      user-select: none;
+      width: 100%;
+    }
+
+    .mermaid-overlay-close {
+      background-color: transparent;
+      border: 1px solid #30363d;
+      border-radius: 5px;
+      color: #9198a1;
+      cursor: pointer;
+      font-size: 18px;
+      line-height: 1;
+      padding: 4px 10px;
+      position: absolute;
+      right: 16px;
+      top: 16px;
+      transition: border-color 0.2s ease, color 0.2s ease;
+      z-index: 1;
+    }
+
+    .mermaid-overlay-close:hover {
+      border-color: #6e7681;
+      color: #c9d1d9;
+    }
+
+    .mermaid-overlay .mermaid-reset-btn {
+      bottom: 16px;
+      right: 16px;
+    }
+
+    @media (prefers-color-scheme: light) {
+      .mermaid-expand-btn svg {
+        fill: #59636e;
+      }
+
+      .mermaid-expand-btn:hover svg {
+        fill: #1f2328;
+      }
+
+      .mermaid-overlay {
+        background-color: rgba(0, 0, 0, 0.6);
+      }
+
+      .mermaid-overlay-close {
+        border-color: #d0d7de;
+        color: #59636e;
+      }
+
+      .mermaid-overlay-close:hover {
+        border-color: #8c959f;
+        color: #1f2328;
+      }
+
+      .mermaid-reset-btn {
+        border-color: #d0d7de;
+        color: #59636e;
+      }
+
+      .mermaid-reset-btn:hover {
+        border-color: #8c959f;
+        color: #1f2328;
+      }
+    }
+
     .markdown-body pre.diagram-map-pre {
       padding: 0;
       overflow: hidden;


### PR DESCRIPTION
Implements https://github.com/thiagokokada/gh-gfm-preview/issues/99

Besides the minimal integration test. I've manually tested with `go run . ~/test-docs.md`, which appears to be working as expected (arguably more convenient than github's implementation).