### PR TITLE
Be complaint with NO_COLOR spec

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -48,12 +48,13 @@ func Execute() {
 		logLevel.Set(slog.LevelDebug)
 	}
 
+	if !(*noColor) {
+		*noColor = getNoColorFromEnv()
+	}
+
 	h := slog.New(tint.NewHandler(
 		os.Stdout,
-		&tint.Options{
-			Level:   logLevel,
-			NoColor: *noColor || os.Getenv("NO_COLOR") == "1",
-		},
+		&tint.Options{Level: logLevel, NoColor: *noColor},
 	))
 	slog.SetDefault(h)
 
@@ -115,4 +116,14 @@ func getVersion() string {
 	}
 
 	return buildInfo.Main.Version
+}
+
+func getNoColorFromEnv() bool {
+	// https://no-color.org/
+	env, ok := os.LookupEnv("NO_COLOR")
+	if ok {
+		return env != ""
+	}
+
+	return false
 }

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/thiagokokada/gh-gfm-preview/internal/assert"
+)
+
+func TestGetNoColorFromEnv(t *testing.T) {
+	assert.False(t, getNoColorFromEnv())
+
+	t.Setenv("NO_COLOR", "")
+	assert.False(t, getNoColorFromEnv())
+
+	t.Setenv("NO_COLOR", "1")
+	assert.True(t, getNoColorFromEnv())
+
+	t.Setenv("NO_COLOR", "foo")
+	assert.True(t, getNoColorFromEnv())
+}


### PR DESCRIPTION
From https://no-color.org/:

> Command-line software which adds ANSI color to its output by default
> should check for a NO_COLOR environment variable that, when present and
> not an empty string (regardless of its value), prevents the addition of
> ANSI color.

Previously to this commit, we would only disable colors if `NO_COLOR == 1`, instead of any non-empty string. This commit makes the code complaint to the spec.