### PR TITLE
Fix live reload lag for atomic saves

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -305,8 +306,10 @@ func mdHandler(filename string, param *Param) http.Handler {
 		pathParam := r.URL.Query().Get("path")
 
 		if pathParam != "" && param.IsDirectoryMode {
-			markdownView, title, err := mdResponseFromRoot(w, pathParam, param)
+			markdownView, title, err := renderMarkdownFromRoot(pathParam, param)
 			if err != nil {
+				writeMarkdownJSONErrorResponse(w, err, path.Base(pathParam))
+
 				return
 			}
 
@@ -352,46 +355,57 @@ func mdHandler(filename string, param *Param) http.Handler {
 }
 
 func mdResponseFromRoot(w http.ResponseWriter, pathParam string, param *Param) (markdownView, string, error) {
-	if param.DirectoryRoot == nil {
-		return writeMarkdownReadError(w, errNoDirectoryRoot), "", errNoDirectoryRoot
-	}
-
 	return mdResponseFromOpenedRoot(w, pathParam, param.DirectoryRoot, param)
 }
 
 func mdResponseFromOpenedRoot(w http.ResponseWriter, pathParam string, root *os.Root, param *Param) (markdownView, string, error) {
-	if root == nil {
-		return writeMarkdownReadError(w, errNoDirectoryRoot), "", errNoDirectoryRoot
-	}
-
-	normalizedPath, ok := normalizeRootPath(pathParam)
-	if !ok {
-		err := fmt.Errorf("%w: %s", app.ErrFileNotFound, pathParam)
-
-		return writeMarkdownReadError(w, err), "", err
-	}
-
-	file, title, err := resolveRootMarkdownTarget(root, normalizedPath)
-	if err != nil {
-		return writeMarkdownReadError(w, err), "", err
-	}
-
-	markdown, err := readRootMarkdown(root, file)
+	markdownView, title, err := renderMarkdownFromOpenedRoot(pathParam, root, param)
 	if err != nil {
 		return writeMarkdownReadError(w, err), "", err
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	markdownView, err := renderMarkdownView(markdown, param)
-	if err != nil {
-		return writeMarkdownRenderError(w, err, param), "", err
-	}
-
 	return markdownView, title, nil
 }
 
+func renderMarkdownFromRoot(pathParam string, param *Param) (markdownView, string, error) {
+	return renderMarkdownFromOpenedRoot(pathParam, param.DirectoryRoot, param)
+}
+
+func renderMarkdownFromOpenedRoot(pathParam string, root *os.Root, param *Param) (markdownView, string, error) {
+	if root == nil {
+		return markdownView{}, "", errNoDirectoryRoot
+	}
+
+	normalizedPath, ok := normalizeRootPath(pathParam)
+	if !ok {
+		err := fmt.Errorf("%w: %s", app.ErrFileNotFound, pathParam)
+
+		return markdownView{}, "", err
+	}
+
+	file, title, err := resolveRootMarkdownTarget(root, normalizedPath)
+	if err != nil {
+		return markdownView{}, "", err
+	}
+
+	markdown, err := readRootMarkdown(root, file)
+	if err != nil {
+		return markdownView{}, "", err
+	}
+
+	view, err := renderMarkdownView(markdown, param)
+	if err != nil {
+		return markdownView{}, "", err
+	}
+
+	return view, title, nil
+}
+
 func writeMarkdownJSONResponse(w http.ResponseWriter, markdownView markdownView, title string) {
+	w.Header().Set("Content-Type", "application/json")
+
 	body, err := json.Marshal(mdResponseJSON{
 		HTML:         markdownView.HTML,
 		Title:        title,
@@ -406,6 +420,16 @@ func writeMarkdownJSONResponse(w http.ResponseWriter, markdownView markdownView,
 	}
 
 	fmt.Fprintf(w, "%s", body)
+}
+
+func writeMarkdownJSONErrorResponse(w http.ResponseWriter, err error, title string) {
+	slog.Error("Error while reading markdown", "error", err)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	writeMarkdownJSONResponse(w, markdownView{
+		HTML: fmt.Sprintf("<pre>%s</pre>", html.EscapeString(err.Error())),
+	}, title)
 }
 
 func resolveRootMarkdownTarget(root *os.Root, pathParam string) (string, string, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -347,8 +347,20 @@ func mdHandler(filename string, param *Param) http.Handler {
 			}
 		}
 
-		markdownView := mdResponse(w, file, param)
 		title := getTitle(file)
+		markdown, err := getMarkdown(file, param)
+		if err != nil {
+			writeMarkdownJSONErrorResponse(w, err, title)
+
+			return
+		}
+
+		markdownView, err := renderMarkdownView(markdown, param)
+		if err != nil {
+			writeMarkdownJSONErrorResponse(w, err, title)
+
+			return
+		}
 
 		writeMarkdownJSONResponse(w, markdownView, title)
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -337,33 +337,36 @@ func mdHandler(filename string, param *Param) http.Handler {
 			return
 		}
 
-		file := filename
-
-		// If the file is a directory, try to find a README file
-		if info, err := os.Stat(file); err == nil && info.IsDir() {
-			readme, err := app.FindReadmeFS(os.DirFS(file), ".")
-			if err == nil {
-				file = filepath.Join(file, readme)
-			}
-		}
-
-		title := getTitle(file)
-		markdown, err := getMarkdown(file, param)
-		if err != nil {
-			writeMarkdownJSONErrorResponse(w, err, title)
-
-			return
-		}
-
-		markdownView, err := renderMarkdownView(markdown, param)
-		if err != nil {
-			writeMarkdownJSONErrorResponse(w, err, title)
-
-			return
-		}
-
-		writeMarkdownJSONResponse(w, markdownView, title)
+		handleSingleFileMarkdownRequest(w, filename, param)
 	})
+}
+
+func handleSingleFileMarkdownRequest(w http.ResponseWriter, filename string, param *Param) {
+	// If the file is a directory, try to find a README file
+	if info, err := os.Stat(filename); err == nil && info.IsDir() {
+		readme, err := app.FindReadmeFS(os.DirFS(filename), ".")
+		if err == nil {
+			filename = filepath.Join(filename, readme)
+		}
+	}
+
+	title := getTitle(filename)
+
+	markdown, err := getMarkdown(filename, param)
+	if err != nil {
+		writeMarkdownJSONErrorResponse(w, err, title)
+
+		return
+	}
+
+	markdownView, err := renderMarkdownView(markdown, param)
+	if err != nil {
+		writeMarkdownJSONErrorResponse(w, err, title)
+
+		return
+	}
+
+	writeMarkdownJSONResponse(w, markdownView, title)
 }
 
 func mdResponseFromRoot(w http.ResponseWriter, pathParam string, param *Param) (markdownView, string, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -59,7 +59,7 @@ func TestMdHandler(t *testing.T) {
 	defer res.Body.Close()
 
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Equal(t, res.Header.Get("Content-Type"), "text/html; charset=utf-8")
+	assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
 
 	body, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
@@ -115,7 +115,7 @@ func TestMdHandlerRendersFootnotesInGFMMode(t *testing.T) {
 	defer res.Body.Close()
 
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Equal(t, res.Header.Get("Content-Type"), "text/html; charset=utf-8")
+	assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
 
 	body, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
@@ -211,7 +211,7 @@ func TestMdHandlerDirectoryModeUsesReadmeForTrailingSlashPath(t *testing.T) {
 	defer res.Body.Close()
 
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Equal(t, res.Header.Get("Content-Type"), "text/html; charset=utf-8")
+	assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
 
 	body, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
@@ -252,9 +252,50 @@ func TestMdHandlerDirectoryModeRejectsEscapingPaths(t *testing.T) {
 			defer res.Body.Close()
 
 			assert.Equal(t, res.StatusCode, http.StatusNotFound)
-			assert.Equal(t, res.Header.Get("Content-Type"), "text/plain; charset=utf-8")
+			assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
 		})
 	}
+}
+
+func TestMdHandlerDirectoryModeReturnsJSONErrorForMissingReloadPath(t *testing.T) {
+	root, err := os.OpenRoot("../../testdata")
+	assert.Nil(t, err)
+
+	defer root.Close()
+
+	param := &Param{
+		DirectoryListing:               true,
+		DirectoryListingShowExtensions: ".md",
+		DirectoryListingTextExtensions: ".md,.txt",
+		IsDirectoryMode:                true,
+		DirectoryPath:                  "../../testdata",
+		DirectoryRoot:                  root,
+		Reload:                         false,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/__/md?path=missing.md", nil)
+	rec := httptest.NewRecorder()
+
+	mdHandler("", param).ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, res.StatusCode, http.StatusNotFound)
+	assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
+
+	body, err := io.ReadAll(res.Body)
+	assert.Nil(t, err)
+
+	var payload mdResponseJSON
+
+	err = json.Unmarshal(body, &payload)
+	assert.Nil(t, err)
+
+	assert.Equal(t, payload.Title, "missing.md")
+	assert.True(t, strings.Contains(payload.HTML, "file not found"))
+	assert.Equal(t, payload.HeadingsHTML, "")
+	assert.False(t, payload.HasHeadings)
 }
 
 func TestMdHandlerRendersMermaid(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -298,6 +298,35 @@ func TestMdHandlerDirectoryModeReturnsJSONErrorForMissingReloadPath(t *testing.T
 	assert.False(t, payload.HasHeadings)
 }
 
+func TestMdHandlerReturnsJSONErrorForMissingSingleFile(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "missing.md")
+	err := os.WriteFile(filename, []byte("# Temporary markdown"), 0o600)
+	assert.Nil(t, err)
+
+	err = os.Remove(filename)
+	assert.Nil(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/__/md", nil)
+	rec := httptest.NewRecorder()
+
+	mdHandler(filename, &Param{}).ServeHTTP(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, res.StatusCode, http.StatusNotFound)
+	assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
+
+	var payload mdResponseJSON
+	err = json.NewDecoder(res.Body).Decode(&payload)
+	assert.Nil(t, err)
+
+	assert.Equal(t, payload.Title, "missing.md")
+	assert.True(t, strings.Contains(payload.HTML, "get markdown error"))
+	assert.Equal(t, payload.HeadingsHTML, "")
+	assert.False(t, payload.HasHeadings)
+}
+
 func TestMdHandlerRendersMermaid(t *testing.T) {
 	filename := "../../testdata/mermaid.md"
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -318,6 +318,7 @@ func TestMdHandlerReturnsJSONErrorForMissingSingleFile(t *testing.T) {
 	assert.Equal(t, res.Header.Get("Content-Type"), "application/json")
 
 	var payload mdResponseJSON
+
 	err = json.NewDecoder(res.Body).Decode(&payload)
 	assert.Nil(t, err)
 

--- a/internal/server/websocket_test.go
+++ b/internal/server/websocket_test.go
@@ -76,9 +76,8 @@ func TestConcurrentWrites(t *testing.T) {
 
 	errorChan := startConcurrentWrites(t, testFile, 100)
 
-	messageCount := readReloadMessages(t, ws, errorChan)
-
-	assert.True(t, messageCount >= 1)
+	waitForConcurrentWrites(t, errorChan)
+	assertReloadMessage(t, ws)
 }
 
 func startConcurrentWrites(t *testing.T, testFile *os.File, numWrites int) <-chan error {
@@ -107,54 +106,35 @@ func startConcurrentWrites(t *testing.T, testFile *os.File, numWrites int) <-cha
 	return errorChan
 }
 
-func readReloadMessages(t *testing.T, ws *websocket.Conn, errorChan <-chan error) int {
+func waitForConcurrentWrites(t *testing.T, errorChan <-chan error) {
 	t.Helper()
 
-	messageCount := 0
 	timeout := time.After(3 * time.Second)
 
 	for {
 		select {
-		case err := <-errorChan:
+		case err, ok := <-errorChan:
+			if !ok {
+				return
+			}
+
 			assert.Nil(t, err)
 		case <-timeout:
-			t.Logf("received %d messages before timeout", messageCount)
-
-			return messageCount
-		default:
-			if tryReadReloadMessage(t, ws, &messageCount) {
-				return messageCount
-			}
+			t.Fatal("timeout waiting for concurrent writes")
 		}
 	}
 }
 
-func tryReadReloadMessage(t *testing.T, ws *websocket.Conn, messageCount *int) bool {
+func assertReloadMessage(t *testing.T, ws *websocket.Conn) {
 	t.Helper()
 
-	err := ws.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	err := ws.SetReadDeadline(time.Now().Add(3 * time.Second))
 	assert.Nil(t, err)
 
 	msgType, msg, err := ws.ReadMessage()
-	if err != nil {
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-			return true
-		}
-
-		if !os.IsTimeout(err) {
-			t.Logf("read error (might be expected): %v", err)
-		}
-
-		time.Sleep(10 * time.Millisecond)
-
-		return false
-	}
-
-	if msgType == websocket.TextMessage && string(msg) == expectedReloadMsg {
-		*messageCount++
-	}
-
-	return *messageCount >= 5
+	assert.Nil(t, err)
+	assert.Equal(t, msgType, websocket.TextMessage)
+	assert.Equal(t, string(msg), expectedReloadMsg)
 }
 
 func TestConcurrentWritesStress(t *testing.T) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -115,7 +115,10 @@ func (w *Watcher) Watch() {
 	}
 
 	re := regexp.MustCompile(ignorePattern)
-	mu := sync.Mutex{}
+	debouncer := newReloadDebouncer(func(path string) {
+		slog.Info("Change detected, refreshing", "path", path)
+		w.MessageCh <- ReloadMessage
+	})
 
 	for {
 		select {
@@ -124,7 +127,7 @@ func (w *Watcher) Watch() {
 				continue
 			}
 
-			w.handleEvent(event, re, &mu)
+			w.handleEvent(event, re, debouncer)
 		case err := <-w.watcher.Errors:
 			slog.Error("FS watcher error", "error", err)
 
@@ -135,7 +138,7 @@ func (w *Watcher) Watch() {
 	}
 }
 
-func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, mu *sync.Mutex) {
+func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, debouncer *reloadDebouncer) {
 	if !isReloadEvent(event) {
 		return
 	}
@@ -144,28 +147,19 @@ func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, mu *sync.
 	op := event.Op
 	base := filepath.Base(path)
 
+	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+		w.watchedDirs.Delete(path)
+	}
+
 	if re.MatchString(base) {
 		slog.Debug("FS event from ignored pattern", "op", op, "path", path)
 
 		return
 	}
 
-	if !mu.TryLock() {
-		slog.Debug("FS event debounced", "op", op, "path", path)
-
-		return
-	}
-
 	slog.Debug("FS event", "op", op, "path", path)
 
-	go func() {
-		defer mu.Unlock()
-
-		time.Sleep(debounceDelay)
-
-		slog.Info("Change detected, refreshing", "path", event.Name)
-		w.MessageCh <- ReloadMessage
-	}()
+	debouncer.Trigger(path)
 }
 
 func isReloadEvent(event fsnotify.Event) bool {
@@ -174,4 +168,47 @@ func isReloadEvent(event fsnotify.Event) bool {
 		event.Has(fsnotify.Chmod) ||
 		event.Has(fsnotify.Rename) ||
 		event.Has(fsnotify.Remove)
+}
+
+type reloadDebouncer struct {
+	delay  time.Duration
+	notify func(string)
+
+	mu         sync.Mutex
+	generation uint64
+	path       string
+}
+
+func newReloadDebouncer(notify func(string)) *reloadDebouncer {
+	return &reloadDebouncer{
+		delay:  debounceDelay,
+		notify: notify,
+	}
+}
+
+func (d *reloadDebouncer) Trigger(path string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.generation++
+	generation := d.generation
+	d.path = path
+
+	time.AfterFunc(d.delay, func() {
+		d.fire(generation)
+	})
+}
+
+func (d *reloadDebouncer) fire(generation uint64) {
+	d.mu.Lock()
+	if generation != d.generation {
+		d.mu.Unlock()
+
+		return
+	}
+
+	path := d.path
+	d.mu.Unlock()
+
+	d.notify(path)
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -148,7 +148,7 @@ func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, debouncer
 	op := event.Op
 	base := filepath.Base(path)
 
-	if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+	if event.Has(fsnotify.Remove | fsnotify.Rename) {
 		w.watchedDirs.Delete(path)
 	}
 
@@ -164,11 +164,13 @@ func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, debouncer
 }
 
 func isReloadEvent(event fsnotify.Event) bool {
-	return event.Has(fsnotify.Write) ||
-		event.Has(fsnotify.Create) ||
-		event.Has(fsnotify.Chmod) ||
-		event.Has(fsnotify.Rename) ||
-		event.Has(fsnotify.Remove)
+	const reloadOps = fsnotify.Write |
+		fsnotify.Create |
+		fsnotify.Chmod |
+		fsnotify.Rename |
+		fsnotify.Remove
+
+	return event.Has(reloadOps)
 }
 
 type reloadDebouncer struct {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -117,6 +117,7 @@ func (w *Watcher) Watch() {
 	re := regexp.MustCompile(ignorePattern)
 	debouncer := newReloadDebouncer(func(path string) {
 		slog.Info("Change detected, refreshing", "path", path)
+
 		w.MessageCh <- ReloadMessage
 	})
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	ignorePattern = `\.swp$|~$|^\.DS_Store$|^4913$`
-	lockTime      = 100 * time.Millisecond
+	debounceDelay = 100 * time.Millisecond
 )
 
 var (
@@ -136,7 +136,7 @@ func (w *Watcher) Watch() {
 }
 
 func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, mu *sync.Mutex) {
-	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) {
+	if !isReloadEvent(event) {
 		return
 	}
 
@@ -161,10 +161,17 @@ func (w *Watcher) handleEvent(event fsnotify.Event, re *regexp.Regexp, mu *sync.
 	go func() {
 		defer mu.Unlock()
 
+		time.Sleep(debounceDelay)
+
 		slog.Info("Change detected, refreshing", "path", event.Name)
-
 		w.MessageCh <- ReloadMessage
-
-		time.Sleep(lockTime)
 	}()
+}
+
+func isReloadEvent(event fsnotify.Event) bool {
+	return event.Has(fsnotify.Write) ||
+		event.Has(fsnotify.Create) ||
+		event.Has(fsnotify.Chmod) ||
+		event.Has(fsnotify.Rename) ||
+		event.Has(fsnotify.Remove)
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -3,10 +3,13 @@ package watcher
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/thiagokokada/gh-gfm-preview/internal/assert"
 )
 
@@ -84,6 +87,67 @@ func TestWatch_DetectsFileWrite(t *testing.T) {
 	}
 }
 
+func TestHandleEvent_DetectsFileChmod(t *testing.T) {
+	w := &Watcher{MessageCh: make(chan []byte, 1)}
+
+	w.handleEvent(
+		fsnotify.Event{Name: "test.md", Op: fsnotify.Chmod},
+		regexp.MustCompile(ignorePattern),
+		&sync.Mutex{},
+	)
+
+	select {
+	case <-w.MessageCh:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for file chmod event")
+	}
+}
+
+func TestHandleEvent_WaitsForDebounceBeforeReload(t *testing.T) {
+	dir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	filePath := filepath.Join(dir, "test.md")
+	err := os.WriteFile(filePath, []byte("initial"), 0o600)
+	assert.Nil(t, err)
+
+	w := &Watcher{MessageCh: make(chan []byte, 1)}
+	re := regexp.MustCompile(ignorePattern)
+	mu := &sync.Mutex{}
+
+	w.handleEvent(
+		fsnotify.Event{Name: filepath.Join(dir, ".test.md.tmp"), Op: fsnotify.Create},
+		re,
+		mu,
+	)
+
+	select {
+	case <-w.MessageCh:
+		t.Fatal("reload signal sent before debounce settled")
+	case <-time.After(debounceDelay / 2):
+		// Success
+	}
+
+	err = os.WriteFile(filePath, []byte("updated"), 0o600)
+	assert.Nil(t, err)
+
+	w.handleEvent(
+		fsnotify.Event{Name: filePath, Op: fsnotify.Create},
+		re,
+		mu,
+	)
+
+	select {
+	case <-w.MessageCh:
+		content, readErr := os.ReadFile(filePath)
+		assert.Nil(t, readErr)
+		assert.Equal(t, string(content), "updated")
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for debounced reload event")
+	}
+}
+
 func TestWatch_DebounceLogic(t *testing.T) {
 	dir, cleanup := setupTestDir(t)
 	defer cleanup()
@@ -100,7 +164,7 @@ func TestWatch_DebounceLogic(t *testing.T) {
 	filePath := filepath.Join(dir, "rapid.txt")
 
 	// Trigger multiple writes rapidly
-	// The watcher logic has a TryLock and a Sleep(lockTime) which is 100ms.
+	// The watcher logic has a TryLock and a debounce delay.
 	// If we write 5 times in 10ms, we should realistically only get 1 or 2 events processed.
 
 	var counter atomic.Uint32
@@ -127,7 +191,7 @@ func TestWatch_DebounceLogic(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // Fast, but distinct enough for fsnotify
 	}
 
-	// Wait longer than the lockTime (100ms) to let the debounce finish
+	// Wait longer than the debounce delay to let the debounce finish
 	time.Sleep(300 * time.Millisecond)
 	close(done)
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -89,11 +88,14 @@ func TestWatch_DetectsFileWrite(t *testing.T) {
 
 func TestHandleEvent_DetectsFileChmod(t *testing.T) {
 	w := &Watcher{MessageCh: make(chan []byte, 1)}
+	debouncer := newReloadDebouncer(func(string) {
+		w.MessageCh <- ReloadMessage
+	})
 
 	w.handleEvent(
 		fsnotify.Event{Name: "test.md", Op: fsnotify.Chmod},
 		regexp.MustCompile(ignorePattern),
-		&sync.Mutex{},
+		debouncer,
 	)
 
 	select {
@@ -114,12 +116,14 @@ func TestHandleEvent_WaitsForDebounceBeforeReload(t *testing.T) {
 
 	w := &Watcher{MessageCh: make(chan []byte, 1)}
 	re := regexp.MustCompile(ignorePattern)
-	mu := &sync.Mutex{}
+	debouncer := newReloadDebouncer(func(string) {
+		w.MessageCh <- ReloadMessage
+	})
 
 	w.handleEvent(
 		fsnotify.Event{Name: filepath.Join(dir, ".test.md.tmp"), Op: fsnotify.Create},
 		re,
-		mu,
+		debouncer,
 	)
 
 	select {
@@ -135,7 +139,7 @@ func TestHandleEvent_WaitsForDebounceBeforeReload(t *testing.T) {
 	w.handleEvent(
 		fsnotify.Event{Name: filePath, Op: fsnotify.Create},
 		re,
-		mu,
+		debouncer,
 	)
 
 	select {
@@ -145,6 +149,97 @@ func TestHandleEvent_WaitsForDebounceBeforeReload(t *testing.T) {
 		assert.Equal(t, string(content), "updated")
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout waiting for debounced reload event")
+	}
+}
+
+func TestHandleEvent_ExtendsDebounceAfterLaterEvents(t *testing.T) {
+	w := &Watcher{MessageCh: make(chan []byte, 1)}
+	re := regexp.MustCompile(ignorePattern)
+	debouncer := newReloadDebouncer(func(string) {
+		w.MessageCh <- ReloadMessage
+	})
+
+	w.handleEvent(
+		fsnotify.Event{Name: "dir", Op: fsnotify.Create},
+		re,
+		debouncer,
+	)
+
+	time.Sleep(debounceDelay / 2)
+
+	w.handleEvent(
+		fsnotify.Event{Name: filepath.Join("dir", "README.md"), Op: fsnotify.Create},
+		re,
+		debouncer,
+	)
+
+	select {
+	case <-w.MessageCh:
+		t.Fatal("reload signal sent before the later event settled")
+	case <-time.After((debounceDelay / 2) + (debounceDelay / 4)):
+		// Success
+	}
+
+	select {
+	case <-w.MessageCh:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for trailing debounced reload event")
+	}
+}
+
+func TestWatch_ReaddsRecreatedDirectory(t *testing.T) {
+	dir, cleanup := setupTestDir(t)
+	defer cleanup()
+
+	subdir := filepath.Join(dir, "subdir")
+	err := os.Mkdir(subdir, 0o700)
+	assert.Nil(t, err)
+
+	w, err := Init(dir)
+	assert.Nil(t, err)
+
+	defer w.Close()
+
+	err = w.AddDirectory(subdir)
+	assert.Nil(t, err)
+
+	go w.Watch()
+	time.Sleep(50 * time.Millisecond)
+
+	err = os.RemoveAll(subdir)
+	assert.Nil(t, err)
+	drainReloadMessages(w.MessageCh)
+
+	err = os.Mkdir(subdir, 0o700)
+	assert.Nil(t, err)
+	drainReloadMessages(w.MessageCh)
+
+	err = w.AddDirectory(subdir)
+	assert.Nil(t, err)
+
+	filePath := filepath.Join(subdir, "test.md")
+	err = os.WriteFile(filePath, []byte("updated"), 0o600)
+	assert.Nil(t, err)
+
+	select {
+	case <-w.MessageCh:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for recreated directory file write event")
+	}
+}
+
+func drainReloadMessages(ch <-chan []byte) {
+	timer := time.NewTimer(2 * debounceDelay)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ch:
+		case <-timer.C:
+			return
+		}
 	}
 }
 
@@ -195,7 +290,7 @@ func TestWatch_DebounceLogic(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	close(done)
 
-	// We expect fewer events than writes because of the lockTime logic
+	// We expect fewer events than writes because of the debounce logic.
 	assert.True(t, counter.Load() > 0)
 	assert.True(t, counter.Load() <= 5)
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -205,6 +205,7 @@ func TestWatch_ReaddsRecreatedDirectory(t *testing.T) {
 	assert.Nil(t, err)
 
 	go w.Watch()
+
 	time.Sleep(50 * time.Millisecond)
 
 	err = os.RemoveAll(subdir)


### PR DESCRIPTION
## Summary

Fix live reload cases where the preview could miss the latest filesystem state, including the "one save behind" behavior reported in #101.

This updates the watcher to handle editor save strategies that do not emit a plain write event, waits until save-related event batches settle before notifying the browser, and makes the Markdown reload endpoint return JSON consistently when the currently previewed path disappears.

## Related Issue

Likely fixes #101.

The reported behavior says live reload is one save behind: saving once does not update the preview, and the next save shows the previous content. That matches the old watcher flow for atomic-save editors such as gedit: an early temporary-file event could trigger reload immediately, while the final target-file replacement happened during the debounce window and was ignored.

## Changes

- Treat `Chmod`, `Rename`, and `Remove` events as reload-worthy watcher events, in addition to `Write` and `Create`.
- Delay reload notifications until after the debounce interval so atomic saves do not refresh before the final file replacement has settled.
- Switch reload coalescing to trailing debounce behavior, so reload happens after the latest event in a save or directory-change batch.
- Remove renamed or deleted paths from the watched-directory cache, allowing recreated directories to be watched again.
- Return JSON from `/__/md` for both successful directory-mode reloads and missing-path reload errors.
- Update websocket, watcher, and server tests to cover coalesced reload behavior, chmod-only updates, atomic-save timing, recreated directories, and missing Markdown reload paths.

## Notes

I did not verify this against gedit directly, but the regression tests cover the underlying event patterns that can produce the lag: metadata-only events, atomic replacement timing, and reloads firing before the final filesystem state is visible.

## Testing

```console
env -u NO_COLOR GOCACHE=/tmp/go-build CGO_ENABLED=0 go test ./...
```
