### PR TITLE
Fix z-index and contrast issues in directory listing and mermaid overlay

### DIFF
--- a/internal/server/static/directory-listing.css
+++ b/internal/server/static/directory-listing.css
@@ -72,7 +72,7 @@
   border: 1px solid #30363d;
   border-radius: 6px;
   box-shadow: 0 8px 24px rgba(1, 4, 9, 0.8);
-  z-index: 999;
+  z-index: 1001;
   overflow: hidden;
 }
 
@@ -86,7 +86,7 @@
   border: 1px solid #30363d;
   border-radius: 6px;
   box-shadow: 0 8px 24px rgba(1, 4, 9, 0.8);
-  z-index: 999;
+  z-index: 1001;
   overflow: hidden;
 }
 

--- a/internal/server/template.html
+++ b/internal/server/template.html
@@ -153,6 +153,10 @@
       width: 100%;
     }
 
+    .mermaid-overlay-inner svg {
+      background-color: #0d1117;
+    }
+
     .mermaid-overlay-close {
       background-color: transparent;
       border: 1px solid #30363d;
@@ -190,6 +194,10 @@
 
       .mermaid-overlay {
         background-color: rgba(0, 0, 0, 0.6);
+      }
+
+      .mermaid-overlay-inner svg {
+        background-color: #ffffff;
       }
 
       .mermaid-overlay-close {


### PR DESCRIPTION
- Raise the `files-popover`/`headings-popover` z-index (999 → 1001) so the
  "Browse Files" and headings dropdowns render above the code-block copy
  button (`z-index: 1000`), which was previously overlapping on top of them.
- Give the zoomed-in mermaid diagram an opaque background (matching the
  light/dark color scheme) so the page content behind the semi-transparent
  overlay no longer shows through and makes the diagram hard to read.